### PR TITLE
snap: extract outputJson() helper in cmd_get.go

### DIFF
--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -166,37 +166,7 @@ func (x *cmdGet) outputList(conf map[string]interface{}) error {
 	return nil
 }
 
-func (x *cmdGet) Execute(args []string) error {
-	if len(args) > 0 {
-		// TRANSLATORS: the %s is the list of extra arguments
-		return fmt.Errorf(i18n.G("too many arguments: %s"), strings.Join(args, " "))
-	}
-
-	if x.Document && x.Typed {
-		return fmt.Errorf("cannot use -d and -t together")
-	}
-
-	if x.Document && x.List {
-		return fmt.Errorf("cannot use -d and -l together")
-	}
-
-	snapName := string(x.Positional.Snap)
-	confKeys := x.Positional.Keys
-
-	cli := Client()
-	conf, err := cli.Conf(snapName, confKeys)
-	if err != nil {
-		return err
-	}
-
-	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
-	switch {
-	case x.Document:
-		return x.outputJson(conf)
-	case x.List || isTerminal:
-		return x.outputList(conf)
-	}
-
+func (x *cmdGet) outputDefault(conf map[string]interface{}, snapName string, confKeys []string) error {
 	rootRequested := len(confKeys) == 0
 	var confToPrint interface{} = conf
 
@@ -228,4 +198,39 @@ func (x *cmdGet) Execute(args []string) error {
 
 	fmt.Fprintln(Stdout, "")
 	return nil
+
+}
+
+func (x *cmdGet) Execute(args []string) error {
+	if len(args) > 0 {
+		// TRANSLATORS: the %s is the list of extra arguments
+		return fmt.Errorf(i18n.G("too many arguments: %s"), strings.Join(args, " "))
+	}
+
+	if x.Document && x.Typed {
+		return fmt.Errorf("cannot use -d and -t together")
+	}
+
+	if x.Document && x.List {
+		return fmt.Errorf("cannot use -d and -l together")
+	}
+
+	snapName := string(x.Positional.Snap)
+	confKeys := x.Positional.Keys
+
+	cli := Client()
+	conf, err := cli.Conf(snapName, confKeys)
+	if err != nil {
+		return err
+	}
+
+	isTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
+	switch {
+	case x.Document:
+		return x.outputJson(conf)
+	case x.List || isTerminal:
+		return x.outputList(conf)
+	default:
+		return x.outputDefault(conf, snapName, confKeys)
+	}
 }

--- a/cmd/snap/cmd_get.go
+++ b/cmd/snap/cmd_get.go
@@ -139,7 +139,7 @@ func flattenConfig(cfg map[string]interface{}, root bool) (values []ConfigValue)
 	return values
 }
 
-func (c *cmdGet) outputJson(conf map[string]interface{}) error {
+func (c *cmdGet) outputJson(conf interface{}) error {
 	bytes, err := json.MarshalIndent(conf, "", "\t")
 	if err != nil {
 		return err
@@ -217,24 +217,15 @@ func (x *cmdGet) Execute(args []string) error {
 		fmt.Fprintf(Stderr, i18n.G(`WARNING: The output of "snap get" will become a list with columns - use -d or -l to force the output format.\n`))
 	}
 
-	if x.Typed && confToPrint == nil {
-		fmt.Fprintln(Stdout, "null")
-		return nil
-	}
-
 	if s, ok := confToPrint.(string); ok && !x.Typed {
 		fmt.Fprintln(Stdout, s)
 		return nil
 	}
 
-	var bytes []byte
-	if confToPrint != nil {
-		bytes, err = json.MarshalIndent(confToPrint, "", "\t")
-		if err != nil {
-			return err
-		}
+	if confToPrint != nil || x.Typed {
+		return x.outputJson(confToPrint)
 	}
 
-	fmt.Fprintln(Stdout, string(bytes))
+	fmt.Fprintln(Stdout, "")
 	return nil
 }


### PR DESCRIPTION
I would like to make cmdGet.Execute() a bit smaller, here is my first (baby) step.

Feel free to ignore for now if you think its not (yet) worth it :)